### PR TITLE
Update pre-commit command to show diff on failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ runs:
       shell: bash
     - run: pre-commit autoupdate
       shell: bash
-    - run: pre-commit run --all-files
+    - run: pre-commit run --all-files --show-diff-on-failure
       shell: bash


### PR DESCRIPTION
Partially addresses #4, but allowing failure and including run's changes in the PR would be ideal.